### PR TITLE
Use OpenSSL's default CA certificate store (often provided by the OS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Replace `PROVIDER_NAME` with the key you used for the provider in the settings h
 
     https://openproject.example.org/auth/google/callback
 
+## Provider SSL certificate validation
+
+This plugin uses OpenSSL's default certificate store (on Linux you can ususally find it in `/etc/ssl/certs`).
+
+If you want to use a different list of CAs for validating provider SSL certificates, you can set the environment variable `SSL_CERT_DIR` to another path containing CA certificates. Note that this environment variable is an OpenSSL feature, so it changes the CA list for all libraries using OpenSSL that don't explicitly specify another path.
+
 ## Credits
 
 This plugin uses some of Neil Hainsworth' [Free Social Icons](http://www.neilorangepeel.com/free-social-icons/).

--- a/lib/open_project/openid_connect/engine.rb
+++ b/lib/open_project/openid_connect/engine.rb
@@ -29,6 +29,12 @@ module OpenProject::OpenIDConnect
         require file.gsub("^.*lib/", "").gsub(".rb", "")
       end
 
+      # Use OpenSSL default certificate store instead of HTTPClient's.
+      # It's outdated and it's unclear how it's managed.
+      OpenIDConnect.http_config do |config|
+        config.ssl_config.set_default_paths
+      end
+
       OmniAuth::OpenIDConnect::Provider.load_generic_providers
 
       app.config.middleware.use OmniAuth::Builder do


### PR DESCRIPTION
httpclient (used via the omniauth-openid_connect and openid_connect
Gems) provides its own list, but that's outdated and e.g. doesn't
include StartCom certificates.

Also, it's not clear which CAs are in httpclient's store and how it's
managed.
